### PR TITLE
docs: document universal env vars for server

### DIFF
--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -4,6 +4,11 @@
 
 Lemonade Server is available as a standalone tool with a [one-click Windows GUI installer](https://github.com/lemonade-sdk/lemonade/releases/latest/download/Lemonade_Server_Installer.exe).
 
+No matter how the server is launched, you can configure its host, port, log
+level, Llama.cpp backend, and context size by setting the environment variables
+`LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`, `LEMONADE_LLAMACPP`, and
+`LEMONADE_CTX_SIZE`.
+
 Once you've installed, we recommend checking out these resources:
 
 | Documentation | Description |

--- a/docs/server/lemonade-server-cli.md
+++ b/docs/server/lemonade-server-cli.md
@@ -44,6 +44,8 @@ lemonade-server run MODEL_NAME [options]
 | `--llamacpp [vulkan\|rocm]`    | Specify the LlamaCpp backend to use | vulkan |
 | `--ctx-size [size]`            | Set the context size for the model. For llamacpp recipes, this sets the `--ctx-size` parameter for the llama server. For other recipes, prompts exceeding this size will be truncated. | 4096 |
 
+These settings can also be provided via environment variables that Lemonade Server recognizes regardless of launch method: `LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`, `LEMONADE_LLAMACPP`, and `LEMONADE_CTX_SIZE`.
+
 The [Lemonade Server integration guide](./server_integration.md) provides more information about how these commands can be used to integrate Lemonade Server into an application.
 
 <!--Copyright (c) 2025 AMD-->

--- a/docs/server/server_integration.md
+++ b/docs/server/server_integration.md
@@ -115,10 +115,10 @@ You can also prevent the server from showing a system tray icon by using the `--
 lemonade-server serve --no-tray
 ```
 
-On Windows installations created with the Lemonade installer, the server can also read
-its host, port, log level, Llama.cpp backend, and context size from environment
-variables. Set `LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`,
-`LEMONADE_LLAMACPP`, or `LEMONADE_CTX_SIZE` before launching `lemonade-server` to
+Regardless of how Lemonade Server is installed or launched, it can read its host,
+port, log level, Llama.cpp backend, and context size from environment variables.
+Set `LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`, `LEMONADE_LLAMACPP`,
+or `LEMONADE_CTX_SIZE` before launching `lemonade-server` by any method to
 override the default settings without editing the startup script.
 
 You can also run the server as a background process using a subprocess or any preferred method.


### PR DESCRIPTION
## Summary
- document that `LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`, `LEMONADE_LLAMACPP`, and `LEMONADE_CTX_SIZE` are honored across all server launch methods
- mention universal environment variable support in CLI guide
- note environment variable configuration options in server README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898fe46e13483309124fea6c78ba5ce