### PR TITLE
Add Harmony prompt renderer option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "openai>=1.81.0,<1.97.1",
         "transformers<=4.53.2",
         "jinja2",
+        "openai-harmony",
         "tabulate",
         "sentencepiece",
         "huggingface-hub[hf_xet]==0.33.0",


### PR DESCRIPTION
## Summary
- add optional Harmony prompt renderer sourced from openai-harmony
- allow disabling jinja templating and building prompts via Harmony
- expose Harmony renderer through `LEMONADE_PROMPT_RENDERER` env var
- include openai-harmony as a runtime dependency

## Testing
- `pytest test/server_llamacpp.py -q` *(fails: FileNotFoundError: No such file or directory: 'lemonade-server-dev')*

------
https://chatgpt.com/codex/tasks/task_e_689d46f8024c8330ab9e9d589ea473b5